### PR TITLE
Minor Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The full Liber Primus is [here](assets/2014/liber-primus-complete).
   * [gematria primus](gematria_primus.md)
   * [irl addresses](irl.md)
   * [pages and ciphers](pages_and_ciphers.md)
-  * [liber primus](liner_primus.md)
+  * [liber primus](liber_primus.md)
   * [possible hints, never used](hints_never_used.md)
   
 ## Links, credit


### PR DESCRIPTION
There was a minor typo in the Markdown for the relative path to Liber Primus (a `n` instead of a `b`).

This caused the link for the `README.md` to lead to a GH "not found" page, but it worked just fine when I clicked on the listing for `liber_primus.md`.