### PR TITLE
Fixing a mistake in The second chance (2012)

### DIFF
--- a/2012.md
+++ b/2012.md
@@ -754,21 +754,13 @@ Finally the DNS entry of `845145127.com` was changed to `127.0.0.1`, and the pre
 # A Second Chance
 <img src="assets/2012/NHYLD.jpg" alt="The Lady of Shallott" width="600" border="2" align="middle"><br>
 
-Some time after emails were sent out to participants who put in their emails on the first Onion, someone (`n_`) posted the URL `1853143003544.tk` in a chat room on `n0v4`. This URL was the sum of the largest factor of each picture name on the QR codes:
+Some time after emails were sent out to participants who put in their emails on the first Onion, someone (`n_`) posted the URL `1853143003544.tk` in a chat room on `n0v4`. This URL was the sum of the largest picture name on the QR codes for each book code:
 
     29-vol:
-    162667212858: 2 3 3 11503 785627
-    316744223127: 3 127 14243 58369
-    414974253863: 13 31921096451
-    427566844663: 7 61169 998561
-    598852142735: 5 7 11 263 1109 5333
-    889296759263: 11 227 1699 209621
-     
+    162667212858, 316744223127, 414974253863, 427566844663, 598852142735, 889296759263
+    
     fading death:
-    644169769482: 2 3 19 53 106615321
-    876873892385: 5 131 1338738767
-    935691396441: 3 499 625044353
-    963846244281: 3 19 23 29 103 246133
+    644169769482, 876873892385, 935691396441, 963846244281
 
 The TXT record for the website said “Go to my largest part”. The largest prime factor of the number in the URL was `33091839349`, so solvers went to `33091839349.tk`. The website's DNS entry contained no TXT, and the site itself was some HTML with a black background and this picture: http://i.imgur.com/NHYLD.jpg. (Please note that at `http://i.imgur.com/NHYLD.jpg` sometimes a car appears now.)<br>
 This picture is The Lady of Shallott, a painting by John William Waterhouse. The painting takes its name from Alfred, Lord Tennyson’s poem of the same name, which, interestingly enough, also deals with Arthurian subject matter.<br>


### PR DESCRIPTION
During the second chance, to get the "Numbers dot TK" URL (`1853143003544.tk`), you had to sum the largest picture name on the QR code for each group (i.e. which book code the QR code lead to) and not "sum of the largest factor of each picture name on the QR codes".

Indeed: max(162667212858, 316744223127, 414974253863, 427566844663, 598852142735, 889296759263) + max(644169769482, 876873892385, 935691396441, 963846244281) = 889296759263 + 963846244281 = 1853143003544

This is also confirmed by a 2012 winner on his website: https://web.archive.org/web/20121226064303/http://bernsteinbear.com/cicada